### PR TITLE
修改了首页，详情页，页脚，导航

### DIFF
--- a/css/_comment_detail.css
+++ b/css/_comment_detail.css
@@ -224,3 +224,12 @@ pre
 	color:#aa2105;
 	position: absolute;
 }
+.comment-item-info-edit
+{
+	float: right;
+}
+.comment-item-info-edit .comment-item-index
+{
+	color:#999;
+	font-size: 12px!important;
+}

--- a/css/_restaurant_item.css
+++ b/css/_restaurant_item.css
@@ -368,7 +368,7 @@ div.view-item .restaurant-detail>ul li strong a:hover,div.view-item .restaurant-
 }
 .view-edit-btn .view-edit-header ul
 {
-	width: 100%;
+	width: 40px;
 	list-style: none;
 	background: #FFFFFF;
     border-radius: 6px 6px 6px 6px;
@@ -380,7 +380,7 @@ div.view-item .restaurant-detail>ul li strong a:hover,div.view-item .restaurant-
     -moz-box-shadow: 0px 3px 7px rgba(0, 0, 0, 0.3);
     -webkit-box-shadow: 0px 3px 7px rgba(0, 0, 0, 0.3);
     -o-box-shadow: 0px 3px 7px rgba(0, 0, 0, 0.3);
-    position: relative;
+    position: absolute;
     z-index: 1060;
     display: none;
 

--- a/css/tang-main.css
+++ b/css/tang-main.css
@@ -66,6 +66,7 @@ body
 #footer a
 {
 	font-size: 14px;
+	color:#999!important;
 }
 
 

--- a/protected/views/comment/_view.php
+++ b/protected/views/comment/_view.php
@@ -17,11 +17,12 @@
 		<div class="info">
 			<span class="source"><?php echo CHtml::encode($data->user->nick_name);?></span>
 			<span class="time"><?php echo CHtml::encode($data->create_datetime);?></span>
-			<div style="float:right;">
-			<?php if (User::model()->isAdmin()) {
-				$actionUrl = $this->createUrl('comment/delete', array('id'=>$data->id));
-				echo CHtml::link('<i class="fa fa-times comment-del" title="删除评论"></i>', $actionUrl);
-			}?>
+			<div class="comment-item-info-edit">
+				<span class="comment-item-index"><?php echo $widget->dataProvider->getPagination()->getOffset() + $index + 1; ?>楼</span>
+				<?php if (User::model()->isAdmin()) {
+					$actionUrl = $this->createUrl('comment/delete', array('id'=>$data->id));
+					echo CHtml::link('<i class="fa fa-times comment-del" title="删除评论"></i>', $actionUrl);
+				}?>
 			</div>
 		</div>
 		<div class="content">			

--- a/protected/views/layouts/main-tang.php
+++ b/protected/views/layouts/main-tang.php
@@ -43,7 +43,7 @@ foreach ($counties as $key => $value)
 foreach ($areas as $key => $value) {
 	$areamenu[]=array('label'=>$value,'url'=>array($this->createUrl('restaurant/index'),'county'=>$key));
 }
-$menu[] = array('label'=>'县区','url'=>array(''),'itemOptions'=>array('class'=>'areamenu'),'items'=>$areamenu);
+$menu[] = array('label'=>'县区','url'=>'#','itemOptions'=>array('class'=>'areamenu'),'items'=>$areamenu);
 ?>
 
 <div id="mainmenu">
@@ -52,7 +52,7 @@ $menu[] = array('label'=>'县区','url'=>array(''),'itemOptions'=>array('class'=
 	<?php $this->widget('zii.widgets.CMenu',array(	
   		//'firstItemCssClass'=>'active',
 		'items'=>$menu,
-		'activeCssClass'=>'active',
+		'activeCssClass'=>false,
   		
 		)); 
 	?>
@@ -131,7 +131,7 @@ $menu[] = array('label'=>'县区','url'=>array(''),'itemOptions'=>array('class'=
 	));
 	}?>
 
-	<a class="qq-login"  href="#" title="QQ登陆"><span>QQ登陆</span></a>
+	<!-- <a class="qq-login"  href="#" title="QQ登陆"><span>QQ登陆</span></a> -->
 	</div>
 </div>
 <div class="modal-backdrop1"></div>
@@ -157,94 +157,93 @@ $menu[] = array('label'=>'县区','url'=>array(''),'itemOptions'=>array('class'=
 <script type="text/javascript" src="<?php echo Yii::app()->request->baseUrl; ?>/js/main_tang.js"></script>
 <script type="text/javascript">
 $(function(){
-var footerHeight = 0,
-footerTop = 0,
-$footer = $("#footer");
-positionFooter();
-//定义positionFooter function
-function positionFooter() {
-//取到div#footer高度
-footerHeight = $footer.height();
-//div#footer离屏幕顶部的距离
-footerTop = ($(window).scrollTop()+$(window).height()-footerHeight)+"px";								
-//如果页面内容高度小于屏幕高度，div#footer将绝对定位到屏幕底部，否则div#footer保留它的正常静态定位
-if ( ($(document.body).height()+footerHeight) < $(window).height()) {
-	$footer.css({
-	position: "absolute"
-	,top: footerTop
-	});
-} else {
-	$footer.css({
-	position: "static"
-	});
+	var footerHeight = 0,
+	footerTop = 0,
+	$footer = $("#footer");
+	positionFooter();
+	//定义positionFooter function
+	function positionFooter() {
+	//取到div#footer高度
+	footerHeight = $footer.height();
+	//div#footer离屏幕顶部的距离
+	footerTop = ($(window).scrollTop()+$(window).height()-footerHeight)+"px";								
+	//如果页面内容高度小于屏幕高度，div#footer将绝对定位到屏幕底部，否则div#footer保留它的正常静态定位
+	if ( ($(document.body).height()+footerHeight) < $(window).height()) {
+		$footer.css({
+		position: "absolute"
+		,top: footerTop
+		});
+	} else {
+		$footer.css({
+		position: "static"
+		});
 
-}
-}
-$(window).scroll(positionFooter).resize(positionFooter);
-
-//点击登陆弹出模态窗口
-$(".login").click(function(){
-	loginModal();
-});
-$(".loginuser").bind("mouseover",function(){
-/*$(this).parent().addClass('show').bind("mouseout",function(){
-
-$(this).removeClass('show');
-});*/
-
-});
-
-$(".modal-backdrop1").click(function(){
-	$("#myModal").hide();
-	$(this).hide();
-});
-$(document.body).keyup(function(event){
-//if(event.ctrlKey && event.which == 13)       //13等于回车键(Enter)键值,ctrlKey 等于 Ctrl
-//alert("按了ctrl+回车键!")
-if(event.keyCode==27)
-	$("#myModal").hide();
-$(".modal-backdrop1").hide();
-});
-
-
-//县菜单鼠标放上去显示下级菜单
-$(".areamenu").hover(function(){
-	$(this).find('ul').show(100);
-},function(){
-	$(this).find('ul').hide(100);
-});
-
-//回到顶部ＪＳ
-$(window).scroll(function(){
-
-	if($(window).scrollTop()>($(document.body).height()/4))
-	{
-		$("#right_float_panel").show();
-	}else
-	{
-		$("#right_float_panel").hide();
 	}
+	}
+	$(window).scroll(positionFooter).resize(positionFooter);
 
-});
 
-//回到顶部功能
-$(".top_up").click(function(){
-	$('html,body').animate({scrollTop:'0px'},500);
-});
+	//菜单选中效果
+	var hostUrl=window.location.href.split(window.location.hostname);
+	if (hostUrl[1]=='/') {
+		hostUrl[1]="<?php echo $this->createUrl('restaurant/index'); ?>";
+	}
+	$("#mainmenu .mainmenu-content>ul>li>a").each(function(){
+		if ($(this).attr('href')==hostUrl[1]) {
+			$(this).parent().attr('class','active');
+		}
+	});
 
-/*
- *类型、区域的A标签加上点击激活状态的样式
- */
-// var currentItem=null;
-// $("#area-menu>ul>li>a").click(function(){
-// 	if (currentItem) {
-// 		currentItem.removeClass('active');
-// 	}
-// 	$(this).addClass('active');
-// 	currentItem=$(this);
 
-// });
+	//点击登陆弹出模态窗口
+	$(".login").click(function(){
+		loginModal();
+	});
+	$(".loginuser").bind("mouseover",function(){
+	/*$(this).parent().addClass('show').bind("mouseout",function(){
 
+	$(this).removeClass('show');
+	});*/
+
+	});
+
+	$(".modal-backdrop1").click(function(){
+		$("#myModal").hide();
+		$(this).hide();
+	});
+	$(document.body).keyup(function(event){
+	//if(event.ctrlKey && event.which == 13)       //13等于回车键(Enter)键值,ctrlKey 等于 Ctrl
+	//alert("按了ctrl+回车键!")
+	if(event.keyCode==27)
+		$("#myModal").hide();
+	$(".modal-backdrop1").hide();
+	});
+
+
+	//县菜单鼠标放上去显示下级菜单
+	$(".areamenu").hover(function(){
+		$(this).find('ul').show(100);
+	},function(){
+		$(this).find('ul').hide(100);
+	});
+
+	//回到顶部ＪＳ
+	$(window).scroll(function(){
+
+		if($(window).scrollTop()>($(document.body).height()/4))
+		{
+			$("#right_float_panel").show();
+		}else
+		{
+			$("#right_float_panel").hide();
+		}
+
+	});
+
+	//回到顶部功能
+	$(".top_up").click(function(){
+		$('html,body').animate({scrollTop:'0px'},500);
+	});
 });
 </script>
 </body>

--- a/protected/views/restaurant/_view.php
+++ b/protected/views/restaurant/_view.php
@@ -73,9 +73,10 @@
 			<!--编辑功能-->
 			<div class="view-edit-btn" >
 				<div class="view-edit-header">
-					<a title="编辑 <?php echo CHtml::encode($data->name); ?>">编辑</a>
+					<a title="编辑 <?php echo CHtml::encode($data->name); ?>" class="fa fa-pencil">编辑</a>
 					<ul>
 						<li class="feature-btn">贴标</li>
+						<li class="itemEdit-btn" data-item-url="<?php echo $this->createUrl('restaurant/update',array('id'=>$data->id)); ?>">修改</li>
 					</ul>
 				</div>
 

--- a/protected/views/restaurant/index.php
+++ b/protected/views/restaurant/index.php
@@ -270,9 +270,10 @@ if (count>limit) {
 				?>	
 				strData+='<!--编辑功能-->';
 				strData+='<div class="view-edit-btn" >'+
-				'<div class="view-edit-header"><a title="编辑 '+item["restaurant"]["name"]+'">编辑</a>'+
+				'<div class="view-edit-header"><a title="编辑 '+item["restaurant"]["name"]+'" class="fa fa-pencil">编辑</a>'+
 				'<ul>'+
 				'<li class="feature-btn">贴标</li>'+
+				'<li class="itemEdit-btn" data-item-url="/restaurant/update/id/'+item["restaurant"]["id"]+'">修改</li>'+
 				'</ul>'+
 				'</div>'+
 				'<div class="feature-content" data-item-id="'+item["restaurant"]["id"]+'" data-selected-items="';
@@ -539,36 +540,42 @@ function tang_main_rating(rating_list,ismouseover)
 					d_this.find("ul").show();
 					d_this.find(".feature-btn").bind("click",function(){
 						var feature_selected_items=$(".feature-content",p_this).attr('data-selected-items').split(',');
-			//ajax加载数据
-			$.get("/restaurantFeature/query",{},function(data){
+						//ajax加载数据
+						$.get("/restaurantFeature/query",{},function(data){
 
-				var t="<ul>";
-				if (data) {
-					$.each(data,function(a){
-						if (isContain(feature_selected_items,data[a].id)) {
-							t+='<li><label><input type="checkbox" value='+data[a].id+' checked="true" />'+data[a].name+'</label> </li>';
-						}
-						else{
-							t+='<li><label><input type="checkbox" value='+data[a].id+' />'+data[a].name+'</label> </li>';
-						}
+							var t="<ul>";
+							if (data) {
+								$.each(data,function(a){
+									if (isContain(feature_selected_items,data[a].id)) {
+										t+='<li><label><input type="checkbox" value='+data[a].id+' checked="true" />'+data[a].name+'</label> </li>';
+									}
+									else{
+										t+='<li><label><input type="checkbox" value='+data[a].id+' />'+data[a].name+'</label> </li>';
+									}
+								});
+							}
+							t+="</ul>";
+							$(".feature-content .feature-content-content",p_this).html(t);
+						},"json");
+
+
+						$(".feature-content",p_this).css({'display':'block',
+							'top':p_this.offset().top+25,
+							'left':p_this.offset().left}).animate(
+							{	
+								width:'200px',
+								minHeight:'200px',
+								left:$(this).offset().left-$(this).width()-200,
+								top:$(this).offset().top-25
+
+							},200);
 					});
-				}
-				t+="</ul>";
-				$(".feature-content .feature-content-content",p_this).html(t);
-			},"json");
+					
+					//编辑导航
+					d_this.find(".itemEdit-btn").bind("click",function(){
+						window.location=$(this).attr('data-item-url');
+					});
 
-
-			$(".feature-content",p_this).css({'display':'block',
-				'top':p_this.offset().top+25,
-				'left':p_this.offset().left}).animate(
-				{	
-					width:'200px',
-					minHeight:'200px',
-					left:$(this).offset().left-$(this).width()-200,
-					top:$(this).offset().top-25
-
-				},200);
-			});
 				},function(){
 					$(this).find("ul").hide();
 					$(this).find(".feature-btn").unbind("click");


### PR DESCRIPTION
首页导航为javascript方式，取到URL拆分hostname在页面上第一行导航里对比；之前的服务端方式只要有site/index,site/index/2这种情况就会把两个都加上选中效果，我看过默认生成的yii webapp里面如果改成这也会出现这效果，只接先用实现；
首页页脚连接color为#999灰色；
详情页的评论数据上加楼层序号显示；
给首页的管理登陆时每个数据项上显示的编辑菜单里加了一个修改数据的菜单 可以直接跳到修改页
