### PR TITLE
解决修改餐馆报错问题。

### DIFF
--- a/protected/controllers/RestaurantController.php
+++ b/protected/controllers/RestaurantController.php
@@ -176,7 +176,6 @@ class RestaurantController extends Controller
 		{
 			$model->attributes=$_POST['Restaurant'];
 
-			$filename = '';
 			$uploadedFile = CUploadedFile::getInstance($model, 'image_url');
 			if (!empty($uploadedFile)) {
 				$extension = $uploadedFile->getExtensionName();				


### PR DESCRIPTION
问题原因：上传图片会进行isset($filename)判断，所以当没有上传图片时，也会进行上传图片流程。解决方法：修改actionUpdate函数：删除$filename='';
