### PR TITLE
解决已删除的评论，仍旧会出现在首页右侧最近评论中

### DIFF
--- a/protected/models/Comment.php
+++ b/protected/models/Comment.php
@@ -119,6 +119,7 @@ class Comment extends CActiveRecord
 	public function getLastComments($limit)
 	{
 		$criteria = new CDbCriteria(array(
+				'condition'=> 'hidden = false',
 				'limit'=> $limit,
 				'offset'=> 0,
 				'order'=>'create_datetime DESC',


### PR DESCRIPTION
查找hidden为false的评论
